### PR TITLE
명사 추출에 실패했을 때의 오류 제거 및 알림 메시지박스 추가

### DIFF
--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -104,7 +104,7 @@ def main():
 		else:
 			messagebox.showwarning(
 				title="Tags 추천",
-				message="추천 해쉬태그가 없습니다."
+				message="2개 이상의 명사를 포함한 글을 입력해주세요."
 			)
 
 

--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -97,8 +97,16 @@ def main():
 		if chkVal.get():
 			t.delete('1.0', END)
 		resultList = nouns(str.get())
-		for x in resultList:
-			t.insert(END, x + ' ')
+
+		if resultList:
+			for x in resultList:
+				t.insert(END, x + ' ')
+		else:
+			messagebox.showwarning(
+				title="Tags 추천",
+				message="추천 해쉬태그가 없습니다."
+			)
+
 
 
 	

--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -32,9 +32,10 @@ def nouns(poststr):
 	postNouns.append(poststr)
 	loop = 0
 
-	for word in postNouns :
-		count_list = Counter(word)
-		postKwords.extend(keyword_counted.search_key(count_list, freq_data, loop))
+	for word in postNouns:
+		if word:
+			count_list = Counter(word)
+			postKwords.extend(keyword_counted.search_key(count_list, freq_data, loop))
 
 	modelDr1 = 'Model1_word2vec.model'
 	modelDr2 = 'Model2_word2vec.model'


### PR DESCRIPTION
Issue #10 을 해결합니다. (더이상 오류가 발생하지 않습니다.)
그리고 만약 명사 추출에 실패했다면 추천 태그가 없게 되고, 사용자가 이를 인지해야 하므로 알림 메시지박스를 추가했습니다.

![image](https://user-images.githubusercontent.com/38099251/58743950-09fb9200-8476-11e9-8a0c-75d4276d6501.png)



