### PR TITLE
okt.nouns()를 쓰레드를 이용해 미리 수행하여 process 시간 단축 & 멀티라인 텍스트박스

### DIFF
--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -3,6 +3,7 @@ from tkinter import ttk, BooleanVar
 import tkinter as tk
 from tkinter import font
 from tkinter import messagebox
+from tkinter.scrolledtext import ScrolledText
 from konlpy import tag
 from konlpy.tag import Okt
 from collections import Counter
@@ -99,7 +100,7 @@ def main():
 	def click():
 		if chkVal.get():
 			t.delete('1.0', END)
-		resultList = nouns(str.get())
+		resultList = nouns(textbox.get('1.0', END))
 
 		if len(resultList)>=2:
 			for x in resultList:
@@ -117,17 +118,15 @@ def main():
 
 
 
-	
-	str = StringVar()
 
 	font = tk.font.Font(size=20, slant="italic")
 	title = tk.Label(window, text="Instagram ###", font=font)
 	title.place(x=250, y=50)
 
 	y1 = int(180)
-	label1 = tk.Label(window, text="문장을 입력하세요")
+	label1 = tk.Label(window, text="본문을 입력하세요")
 	label1.place(x=50, y=y1-25)
-	textbox = ttk.Entry(window, width=60, textvariable=str)
+	textbox = ScrolledText(window, height=6, width=60)
 	textbox.place(x=50, y=y1)
 
 	action = ttk.Button(window, text="loading...", command=click, state=DISABLED)

--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -9,6 +9,7 @@ from collections import Counter
 import pickle
 import keyword_counted
 import gensim
+import threading
 
 
 def strip_e(st):
@@ -20,7 +21,6 @@ def nouns(poststr):
 	with open('Dataset1/insta_counted.bin', 'rb') as f2:
 		freq_data = pickle.load(f2)
 
-	okt = Okt()
 	postNouns = []
 	modelResList1 = []
 	modelResList2 = []
@@ -78,6 +78,9 @@ def nouns(poststr):
 
 def main():
 	
+	global okt
+
+	okt = Okt()
 	resultList = []
 	
 	window=tk.Tk()
@@ -108,6 +111,11 @@ def main():
 			)
 
 
+	def initOktNouns():
+		okt.nouns("가")
+		action.config(text="process", state=NORMAL)
+
+
 
 	
 	str = StringVar()
@@ -122,7 +130,7 @@ def main():
 	textbox = ttk.Entry(window, width=60, textvariable=str)
 	textbox.place(x=50, y=y1)
 
-	action = ttk.Button(window, text="process", command=click)
+	action = ttk.Button(window, text="loading...", command=click, state=DISABLED)
 	action.place(x=500, y=y1-2)
 
 	y2 = 300
@@ -136,6 +144,10 @@ def main():
 	print()
 	checkact = ttk.Checkbutton(window, text="auto remove", var=chkVal)
 	checkact.place(x=500, y=y2-25)
+
+	t1 = threading.Thread(target=initOktNouns)
+	t1.daemon = True
+	t1.start()
 
 	window.mainloop()
 	

--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -132,7 +132,7 @@ def main():
 	action = ttk.Button(window, text="loading...", command=click, state=DISABLED)
 	action.place(x=500, y=y1-2)
 
-	y2 = 300
+	y2 = 340
 	label2 = tk.Label(window, text="추천 해쉬태그:")
 	label2.place(x=50, y=y2-25)
 	t = Text(window,height=3, width=77)


### PR DESCRIPTION
#16 을 해결합니다.

**수정사항 1**
기존 프로그램에서는 처음 process 버튼을 누르면 대략 3초가 걸릴 정도로 오랜 시간이 소요됩니다. 그 이유는 okt.nouns()를 처음 호출했을때 무거운 초기화 작업이 발생하기 때문입니다. 쓰레드를 생성하여 okt.nouns()를 미리 호출하도록 해서 최초의 process 시간을 단축했습니다. 쓰레드를 사용했기 때문에 로딩중에 다른 작업을 동시에 할 수 있습니다. 또한 처음에는 process 버튼을 비활성화하고 초기화 작업이 완료되면 활성화 하도록 구현했습니다. 사용자 경험 면에서 좋은 패치라고 생각합니다.

**TEST**
입력 : `계단 그림자 기다리는 중. 필카의 묘미.`  
시간을 측정하는 코드는 따로 만들었습니다.

* 기존 코드
```
['필카', '그림자']
['인화', '일회용', '필름', '어플', '맘', '구닥', '자욱', '흐릿', '렁', '수평선', '번쩍', '깜깜', '필카', '그림자']
['사람', '필카', '친구', '코닥', '#필카감성', '#셀피', '필름', '#구닥']
시간(초) :  3.003657817840576
```

* 수정한 코드
```
['필카', '그림자']
['인화', '일회용', '필름', '어플', '맘', '구닥', '자욱', '흐릿', '렁', '수평선', '번쩍', '깜깜', '필카', '그림자']
['사람', '필카', '친구', '코닥', '#필카감성', '#셀피', '필름', '#구닥']
시간(초) : 0.5177783966064453
```

<br />

**수정사항 2**
기존 프로그램은 본문 입력창이 1줄이라 줄바꿈이 불가능했고, 스크롤바가 생기지 않아 편집시 불편함이 있었습니다. 이 PR은 해당 사항을 개선하여, 여러 줄의 본문을 입력할 수 있게 했고 스크롤바를 부착시켰습니다.

![image](https://user-images.githubusercontent.com/38099251/59007475-6fc69000-8861-11e9-9441-f15dd8bd362d.png)
