### PR TITLE
명사가 2개 이하일 때 20배 정도의 성능 향상

### DIFF
--- a/Recommend_tags.py
+++ b/Recommend_tags.py
@@ -29,6 +29,10 @@ def nouns(poststr):
 
 	poststr = strip_e(poststr)
 	poststr = (okt.nouns(poststr))
+
+	if len(poststr) < 2 :
+		return []
+
 	postNouns.append(poststr)
 	loop = 0
 
@@ -99,15 +103,15 @@ def main():
 		if chkVal.get():
 			t.delete('1.0', END)
 		resultList = nouns(str.get())
-
-		if len(resultList)>=2:
-			for x in resultList:
-				t.insert(END, x + ' ')
-		else:
+		if len(resultList) < 2 :
 			messagebox.showwarning(
 				title="Tags 추천",
 				message="2개 이상의 명사를 포함한 글을 입력해주세요."
 			)
+		else:
+			for x in resultList:
+				t.insert(END, x + ' ')
+
 
 	######################################
 	label3 = ttk.Label(window)


### PR DESCRIPTION
프로그램 자체를 건드는 내용이라 따로 PR 남깁니다.

기존의 프로그램 구조는, 일단 입력문에서 명사를 추출하고, 그 명사들로 word2vec을 돌린 후 나온 리스트의 원소의 갯수를 비교하는 것으로 알고 있습니다. nouns() 함수 초반에 입력문에서 추출된 명사의 갯수를 이미 알고 있는데, word2vec를 돌려서 오버헤드가 생기는 것으로 보여 프로그램을 약간 고쳤습니다. Okt로 명사를 추출한 직후 바로 명사의 갯수를 세어서 2개 미만일 시  word2vec를 돌리지 않고 즉시 nouns()를 종료시키도록 하였습니다.

 직접 time 함수로 간단하게 성능 비교를 해 보았습니다.
테스트 케이스는 3개 사용했습니다. 세 문장 모두 명사가 2개 이하라는 팝업창이 뜨는 문장입니다.

- 페이지를 찾지 못했습니다
- 단어가없지여긴
- 공부안할래요

다음은 기존의 프로그램으로 돌린 결과입니다. 단위는 초(sec)입니다.

![기존](https://user-images.githubusercontent.com/11948404/59532792-ae74de00-8f24-11e9-9f7c-799c74220b62.PNG)

아래는 제가 개선한 대로 돌린 결과입니다.

![개선](https://user-images.githubusercontent.com/11948404/59532846-cba9ac80-8f24-11e9-8fa5-d8ce2056a945.PNG)

 프로그램을 시작하고 처음 돌리는 문장은 모두 시간이 비교적 오래 걸리는 편인데, 
여기서도 약 0.8초의 개선을 보입니다.
2번째부터는 비약적으로 성능이 향상되어, 0.6초의 시간이 걸리던 게 0.03초 단위로 줄어들었습니다.

 검토 부탁드리겠습니다.


